### PR TITLE
(feature) changing address of DIT London office as per request

### DIFF
--- a/assets/data/regional-offices/london.yml
+++ b/assets/data/regional-offices/london.yml
@@ -1,7 +1,9 @@
 name: DIT London
 address:
-  street: 10-12 Queen Elizabeth Street
+  street:
+    - 6th Floor
+    - 140 Aldersgate Street 
   city: London
-  postcode: SE1 2JN
+  postcode: EC1A 4HY
 email: export@tradelondon.org.uk
 phone: 020 7234 3000


### PR DESCRIPTION
As per this ticket: 
https://trello.com/c/vB4zSJFD/992-3-change-of-address-on-contact-form

this updates the address of DIT London Regional office, on the ‘Office finder’ form (screenshot of latest attached)

![screenshot-localhost-8080 2017-09-19 18-34-31-870](https://user-images.githubusercontent.com/53975/30606310-3ad01946-9d69-11e7-8a82-8f62bdfea5dd.png)