### PR TITLE
Lock node js buildbpack to version 1.6.11

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,9 +1,5 @@
 ---
 applications:
 - name: contact-ukti
-  instances: 2
-  memory: 512M
-  disk_quota: 2G
-  buildpack: nodejs_buildpack
+  buildpack: https://github.com/cloudfoundry/nodejs_buildpack.git#v1.6.15
   command: node .
-  

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
 - name: contact-ukti
-  buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.6.15
+  buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.6.11
   command: node .

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
 - name: contact-ukti
-  buildpack: https://github.com/cloudfoundry/nodejs_buildpack.git#v1.6.15
+  buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.6.15
   command: node .


### PR DESCRIPTION
This is due to multiple dependency issues if the node version is upgraded.